### PR TITLE
Update authselect.spec.in

### DIFF
--- a/rpm/authselect.spec.in
+++ b/rpm/authselect.spec.in
@@ -247,8 +247,8 @@ if [ -f %{validfile} ]; then
     %__rm -f %{validfile}
 fi
 
-# Add nss-altfiles if we are on Silverblue
-if %__grep -i silverblue /etc/os-release &> /dev/null; then
+# Add nss-altfiles if we are on Kinoite or Silverblue
+if %__grep -Ei "kinoite|silverblue" /etc/os-release &> /dev/null; then
     for PROFILE in `ls %{_datadir}/authselect/default`; do
         %{_bindir}/authselect create-profile $PROFILE --vendor --base-on $PROFILE --symlink-pam --symlink-dconf --symlink=REQUIREMENTS --symlink=README &> /dev/null
         %__sed -ie "s/^\(passwd\|group\):\(.*\)systemd\(.*\)/\1:\2systemd altfiles\3/g" %{_datadir}/authselect/vendor/$PROFILE/nsswitch.conf &> /dev/null


### PR DESCRIPTION
spec: Add nss-altfiles for Kinoite

Like on Silverblue, this module is required on Kinoite as well.
This change extends what was done in commit https://github.com/authselect/authselect/commit/9e14ff3cd1cb8a84561d1b8adeaf00c42c4ce5c4 to include Kinoite.